### PR TITLE
Manually send LINK instead of using `fund-link` task

### DIFF
--- a/deploy/01_Deploy_CryptoBooks.ts
+++ b/deploy/01_Deploy_CryptoBooks.ts
@@ -20,7 +20,6 @@ const deployCryptoBooks: DeployFunction = async function (
     LinkToken = await get("LinkToken");
     VRFCoordinatorMock = await get("VRFCoordinatorMock");
     linkTokenAddress = LinkToken.address;
-    console.log("LinkToken address: " + LinkToken.address);
     vrfCoordinatorAddress = VRFCoordinatorMock.address;
   } else {
     linkTokenAddress = networkConfig[chainId].linkToken;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
     "outDir": "dist",
     "declaration": true
   },
-  "include": ["./scripts", "./test", "./typechain", "./deploy"],
+  "include": ["./scripts", "./test", "./typechain-types", "./deploy"],
   "files": ["helper-hardhat-config.ts", "hardhat.config.ts",]
 }


### PR DESCRIPTION
The `fund-link` task produces logs that clutter up the
logs when we are testing. Removes the usage of `fund-link`
in the tests, and replaces this with a manual interaction
with the `LinkToken` contract.

Modify the `tsconfig.json` file so it inspects the types
present in `typechain-types`. This resolves an issue with
the ethers function `getContractAt`, where it was resolving
the return type as a generic `Contract` instead of a concrete
contract type.